### PR TITLE
Add arg to control adding channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ bash change_file_names.sh Dataset012_3Dircadb1Liver/labelsTr/
 
 * Images:
 ```
-bash change_file_names.sh Dataset012_3Dircadb1Liver/imagesTr/
+bash change_file_names.sh Dataset012_3Dircadb1Liver/imagesTr/ true
 ```
 
 4. To pack .nii files to .nii.gz run:

--- a/change_file_names.sh
+++ b/change_file_names.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -xe
 dir=$1
+is_training_sample=$2
+
+if [ $is_training_sample ]; then
+    channel='_0000'
+fi
 
 idx=0
 for f in "$dir"/*; do
@@ -11,6 +16,6 @@ for f in "$dir"/*; do
     else
         file_idx="$idx"
     fi
-    mv $f $dir/train_"$file_idx"_0000.nii
+    mv $f $dir/Dircadb_"$file_idx"$channel.nii.gz
     idx=$((idx+1));
 done


### PR DESCRIPTION
Labels should be just patient number while training samples should have channel. This option allows user to not add channel number to files.